### PR TITLE
Parse input field color opacities from string

### DIFF
--- a/Packages/com.cdm.figma.ui/Runtime/ComponentConverters/InputFieldComponentConverter.cs
+++ b/Packages/com.cdm.figma.ui/Runtime/ComponentConverters/InputFieldComponentConverter.cs
@@ -50,11 +50,13 @@ namespace Cdm.Figma.UI
                     if (componentData != null)
                     {
                         var selectionColor = (UnityEngine.Color)componentData.selectionColor;
-                        componentData.selectionColor.a = componentData.selectionColorOpacity / 100f;
+                        if (float.TryParse(componentData.selectionColorOpacity, out var selectionOpacity))
+                            selectionColor.a = selectionOpacity / 100f;
                         inputField.selectionColor = selectionColor;
 
                         var caretColor = (UnityEngine.Color)componentData.caretColor;
-                        componentData.caretColor.a = componentData.caretColorOpacity / 100f;
+                        if (float.TryParse(componentData.caretColorOpacity, out var caretOpacity))
+                            caretColor.a = caretOpacity / 100f;
                         inputField.caretColor = caretColor;
 
                         inputField.caretWidth = componentData.caretWidth;
@@ -71,7 +73,7 @@ namespace Cdm.Figma.UI
 
             return figmaNode;
         }
-        
+
         private void AppendPaddingToMask(FigmaNode figmaNode, TMP_Text textComponent, TMP_InputField inputField)
         {
             float horizontalPadding = GetPadding(figmaNode.rectTransform, textComponent.rectTransform, RectTransform.Axis.Horizontal);

--- a/Packages/com.cdm.figma.ui/Runtime/ComponentConverters/InputFieldComponentData.cs
+++ b/Packages/com.cdm.figma.ui/Runtime/ComponentConverters/InputFieldComponentData.cs
@@ -12,14 +12,14 @@ namespace Cdm.Figma.UI
         public Color selectionColor { get; set; }
 
         [DataMember]
-        public int selectionColorOpacity { get; set; } = 75;
-        
+        public string selectionColorOpacity { get; set; } = "75";
+
         [DataMember]
         [JsonConverter(typeof(ColorHexJsonConverter))]
         public Color caretColor { get; set; }
 
         [DataMember]
-        public int caretColorOpacity { get; set; } = 100;
+        public string caretColorOpacity { get; set; } = "100";
 
         [DataMember]
         public int caretWidth { get; set; } = 1;


### PR DESCRIPTION
Update input field component data to store selection and caret color opacity values as strings instead of integers. This change ensures compatibility with string-based plugin data and resolves a silent JSON deserialization failure that prevented all input field plugin data from being retrieved.
