### PR TITLE
Parse input field color opacities from string

### DIFF
--- a/Packages/com.cdm.figma.ui/CHANGELOG.md
+++ b/Packages/com.cdm.figma.ui/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.9.4] - 2026-06-08
+- Update input field component data to store selection and caret color opacity values as strings instead of integers. This change ensures compatibility with string-based plugin data and resolves a silent JSON deserialization failure that prevented all input field plugin data from being retrieved.
+
 ## [1.9.3] - 2025-11-25
 - Text Area's RectMask2D of InputField component now has padding so that the caret is not at the border of text at the left most or right most position.
 

--- a/Packages/com.cdm.figma.ui/Runtime/ComponentConverters/InputFieldComponentConverter.cs
+++ b/Packages/com.cdm.figma.ui/Runtime/ComponentConverters/InputFieldComponentConverter.cs
@@ -1,4 +1,5 @@
-﻿using Cdm.Figma.UI.Utils;
+﻿using System.Globalization;
+using Cdm.Figma.UI.Utils;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -50,13 +51,15 @@ namespace Cdm.Figma.UI
                     if (componentData != null)
                     {
                         var selectionColor = (UnityEngine.Color)componentData.selectionColor;
-                        if (float.TryParse(componentData.selectionColorOpacity, out var selectionOpacity))
-                            selectionColor.a = selectionOpacity / 100f;
+                        selectionColor.a = float.TryParse(componentData.selectionColorOpacity, NumberStyles.Float, CultureInfo.InvariantCulture, out var selectionOpacity)
+                            ? selectionOpacity / 100f
+                            : 0.75f;
                         inputField.selectionColor = selectionColor;
 
                         var caretColor = (UnityEngine.Color)componentData.caretColor;
-                        if (float.TryParse(componentData.caretColorOpacity, out var caretOpacity))
-                            caretColor.a = caretOpacity / 100f;
+                        caretColor.a = float.TryParse(componentData.caretColorOpacity, NumberStyles.Float, CultureInfo.InvariantCulture, out var caretOpacity)
+                            ? caretOpacity / 100f
+                            : 1f;
                         inputField.caretColor = caretColor;
 
                         inputField.caretWidth = componentData.caretWidth;

--- a/Packages/com.cdm.figma.ui/Runtime/ComponentConverters/InputFieldComponentConverter.cs
+++ b/Packages/com.cdm.figma.ui/Runtime/ComponentConverters/InputFieldComponentConverter.cs
@@ -50,11 +50,13 @@ namespace Cdm.Figma.UI
                     if (componentData != null)
                     {
                         var selectionColor = (UnityEngine.Color)componentData.selectionColor;
-                        componentData.selectionColor.a = componentData.selectionColorOpacity / 100f;
+                        if (float.TryParse(componentData.selectionColorOpacity, out var selectionOpacity))
+                            selectionColor.a = selectionOpacity / 100f;
                         inputField.selectionColor = selectionColor;
 
                         var caretColor = (UnityEngine.Color)componentData.caretColor;
-                        componentData.caretColor.a = componentData.caretColorOpacity / 100f;
+                        if (float.TryParse(componentData.caretColorOpacity, out var caretOpacity))
+                            caretColor.a = caretOpacity / 100f;
                         inputField.caretColor = caretColor;
 
                         inputField.caretWidth = componentData.caretWidth;
@@ -71,7 +73,7 @@ namespace Cdm.Figma.UI
 
             return figmaNode;
         }
-        
+
         private void AppendPaddingToMask(FigmaNode figmaNode, TMP_Text textComponent, TMP_InputField inputField)
         {
             float horizontalPadding = GetPadding(figmaNode.rectTransform, textComponent.rectTransform, RectTransform.Axis.Horizontal);

--- a/Packages/com.cdm.figma.ui/Runtime/ComponentConverters/InputFieldComponentData.cs
+++ b/Packages/com.cdm.figma.ui/Runtime/ComponentConverters/InputFieldComponentData.cs
@@ -12,14 +12,14 @@ namespace Cdm.Figma.UI
         public Color selectionColor { get; set; }
 
         [DataMember]
-        public int selectionColorOpacity { get; set; } = 75;
-        
+        public string selectionColorOpacity { get; set; } = "75";
+
         [DataMember]
         [JsonConverter(typeof(ColorHexJsonConverter))]
         public Color caretColor { get; set; }
 
         [DataMember]
-        public int caretColorOpacity { get; set; } = 100;
+        public string caretColorOpacity { get; set; } = "100";
 
         [DataMember]
         public int caretWidth { get; set; } = 1;

--- a/Packages/com.cdm.figma.ui/package.json
+++ b/Packages/com.cdm.figma.ui/package.json
@@ -1,13 +1,13 @@
 {
   "name": "com.cdm.figma.ui",
   "displayName": "Unity Figma Importer - UGUI",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "unity": "2021.3",
   "author": "CDM Vision",
   "description": "Unity Figma Importer turns your Figma design into Unity UI elements and can generate code and layout files to create Unity apps.",
   "hideInEditor": false,
   "dependencies": {
-    "com.cdm.figma": "1.9.3",
+    "com.cdm.figma": "1.9.4",
     "com.unity.nuget.newtonsoft-json": "2.0.2",
     "com.unity.vectorgraphics": "2.0.0-preview.24"
   }

--- a/Packages/com.cdm.figma/CHANGELOG.md
+++ b/Packages/com.cdm.figma/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.9.4] - 2026-06-08
+- No changes
+
 ## [1.9.3] - 2025-11-25
 - No changes
 

--- a/Packages/com.cdm.figma/package.json
+++ b/Packages/com.cdm.figma/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.cdm.figma",
   "displayName": "Unity Figma Importer",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "unity": "2021.3",
   "author": "CDM Vision",
   "description": "Unity Figma Importer turns your Figma design into Unity UI and can generate code and layout files to create Unity apps.",


### PR DESCRIPTION
Update input field component data to store selection and caret color opacity values as strings instead of integers. This change ensures compatibility with string-based plugin data and resolves a silent JSON deserialization failure that prevented all input field plugin data from being retrieved.