### PR TITLE
Fix NullReferenceException when autoSizeTextContainer is applied to a text that has not awakened

### DIFF
--- a/Packages/com.cdm.figma.ui/Runtime/Styles/TextStyle.cs
+++ b/Packages/com.cdm.figma.ui/Runtime/Styles/TextStyle.cs
@@ -94,7 +94,14 @@ namespace Cdm.Figma.UI.Styles
                     textComponent.enableWordWrapping = wordWrapping.value;
 
                 if (autoSizeTextContainer.enabled)
-                    textComponent.autoSizeTextContainer = autoSizeTextContainer.value;
+                {
+                    // Setting this to true registers the text with the CanvasUpdateRegistry right away,
+                    // and Rebuild() then dereferences m_rectTransform, which is only cached in Awake().
+                    // Skip it while the component is not live; the field is not serialized, so setting
+                    // it on a prefab asset would not persist anyway.
+                    if (!autoSizeTextContainer.value || textComponent.isActiveAndEnabled)
+                        textComponent.autoSizeTextContainer = autoSizeTextContainer.value;
+                }
 
                 if (horizontalAlignment.enabled)
                     textComponent.horizontalAlignment = horizontalAlignment.value;


### PR DESCRIPTION
`TextStyle.SetStyle` assigns `autoSizeTextContainer` on the TMP component. TMP's setter immediately calls `CanvasUpdateRegistry.RegisterCanvasElementForLayoutRebuild`, so on the next canvas update `TextMeshProUGUI.Rebuild` runs `m_rectTransform.sizeDelta = GetPreferredValues(...)`. `m_rectTransform` is only cached in `Awake`, so when a style is applied to a prefab asset or an inactive instance it is still null and the editor logs:

```
NullReferenceException: Object reference not set to an instance of an object
TMPro.TextMeshProUGUI.Rebuild (UnityEngine.UI.CanvasUpdate update) at TextMeshProUGUI.cs:222
UnityEngine.UI.CanvasUpdateRegistry.PerformUpdate () at CanvasUpdateRegistry.cs:181
```

`Rebuild` is the only TMP entry point without an `m_isAwake` guard, and line 222 is its only unguarded dereference, so this is the one way the method can throw.

The fix assigns `true` only when the component is live. Assigning `false` stays unconditional because it never registers. `m_autoSizeTextContainer` is not serialized, so setting it on a prefab asset never persisted anyway.

Verified in a consuming project by driving the real `TextStyle.SetStyle`:

| case | auto size applied | Rebuild NREs |
|---|---|---|
| not awake, before fix | yes | 1 |
| not awake, after fix | no | 0 |
| awake, after fix | yes | 0 |
