### PR TITLE
2.0.0: faster import and stable design references

### DIFF
--- a/Packages/com.cdm.figma.ui/CHANGELOG.md
+++ b/Packages/com.cdm.figma.ui/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.0.0] - 2026-08-16
 ### Changes
 - Every design is reimported once after upgrading, because this version produces different sprites, tessellation and thumbnails.
-- Import results can be cached by the Unity Accelerator. Where a cache server is configured, returning to a design that has already been imported no longer costs a full import.
 - The colour of a shape painted in one solid colour is applied through its image style, so colour variants can share a sprite.
 - A design still imports when Unity Localization cannot resolve an entry. That used to abandon the import and leave the design with nothing in it.
 

--- a/Packages/com.cdm.figma.ui/CHANGELOG.md
+++ b/Packages/com.cdm.figma.ui/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-08-16
+### Changes
+- Every design is reimported once after upgrading, because this version produces different sprites, tessellation and thumbnails.
+- Import results can be cached by the Unity Accelerator. Where a cache server is configured, returning to a design that has already been imported no longer costs a full import.
+- The colour of a shape painted in one solid colour is applied through its image style, so colour variants can share a sprite.
+
 ## [1.9.5] - 2026-08-14
 - Fix NullReferenceException when autoSizeTextContainer is applied to a text that has not awakened.
 

--- a/Packages/com.cdm.figma.ui/CHANGELOG.md
+++ b/Packages/com.cdm.figma.ui/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Every design is reimported once after upgrading, because this version produces different sprites, tessellation and thumbnails.
 - Import results can be cached by the Unity Accelerator. Where a cache server is configured, returning to a design that has already been imported no longer costs a full import.
 - The colour of a shape painted in one solid colour is applied through its image style, so colour variants can share a sprite.
+- A design still imports when Unity Localization cannot resolve an entry. That used to abandon the import and leave the design with nothing in it.
 
 ## [1.9.5] - 2026-08-14
 - Fix NullReferenceException when autoSizeTextContainer is applied to a text that has not awakened.

--- a/Packages/com.cdm.figma.ui/Editor/FigmaAssetImporter.cs
+++ b/Packages/com.cdm.figma.ui/Editor/FigmaAssetImporter.cs
@@ -14,9 +14,8 @@ using Object = UnityEngine.Object;
 namespace Cdm.Figma.UI.Editor
 {
     // Raise the version whenever a change alters what is imported, otherwise projects keep the
-    // artifacts built by the previous code. AllowCaching shares those artifacts through the Unity
-    // Accelerator, so the version is also what stops one machine being served another machine's.
-    [ScriptedImporter(2, DefaultExtension, ImportQueueOffset, AllowCaching = true)]
+    // artifacts built by the previous code.
+    [ScriptedImporter(2, DefaultExtension, ImportQueueOffset)]
     public class FigmaAssetImporter : FigmaAssetImporterBase
     {
         private const string TextMeshProSettingsAssetPath = "Assets/TextMesh Pro/Resources/TMP Settings.asset";

--- a/Packages/com.cdm.figma.ui/Editor/FigmaAssetImporter.cs
+++ b/Packages/com.cdm.figma.ui/Editor/FigmaAssetImporter.cs
@@ -13,7 +13,10 @@ using Object = UnityEngine.Object;
 
 namespace Cdm.Figma.UI.Editor
 {
-    [ScriptedImporter(1, DefaultExtension, ImportQueueOffset)]
+    // Raise the version whenever a change alters what is imported, otherwise projects keep the
+    // artifacts built by the previous code. AllowCaching shares those artifacts through the Unity
+    // Accelerator, so the version is also what stops one machine being served another machine's.
+    [ScriptedImporter(2, DefaultExtension, ImportQueueOffset, AllowCaching = true)]
     public class FigmaAssetImporter : FigmaAssetImporterBase
     {
         private const string TextMeshProSettingsAssetPath = "Assets/TextMesh Pro/Resources/TMP Settings.asset";
@@ -449,8 +452,7 @@ namespace Cdm.Figma.UI.Editor
 
         private void SearchAndAddFigmaNodeBehaviours(FigmaImporter figmaImporter)
         {
-            var nodeBehaviours = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(a => a.GetTypes().Where(t => t.IsDefined(typeof(FigmaNodeAttribute))));
+            var nodeBehaviours = AttributedTypes.With(typeof(FigmaNodeAttribute));
 
             foreach (var type in nodeBehaviours)
             {
@@ -484,8 +486,7 @@ namespace Cdm.Figma.UI.Editor
 
         private void SearchAndAddFigmaComponentBehaviours(FigmaImporter figmaImporter)
         {
-            var componentBehaviours = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(a => a.GetTypes().Where(t => t.IsDefined(typeof(FigmaComponentAttribute))));
+            var componentBehaviours = AttributedTypes.With(typeof(FigmaComponentAttribute));
 
             foreach (var type in componentBehaviours)
             {
@@ -510,8 +511,7 @@ namespace Cdm.Figma.UI.Editor
 
         private void SearchAndAddComponentConverters(FigmaImporter figmaImporter)
         {
-            var componentConverters = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(a => a.GetTypes().Where(t => t.IsDefined(typeof(FigmaComponentConverterAttribute))));
+            var componentConverters = AttributedTypes.With(typeof(FigmaComponentConverterAttribute));
 
             foreach (var type in componentConverters)
             {
@@ -536,8 +536,7 @@ namespace Cdm.Figma.UI.Editor
 
         private void SearchAndAddNodeConverters(FigmaImporter figmaImporter)
         {
-            var nodeConverters = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(a => a.GetTypes().Where(t => t.IsDefined(typeof(FigmaNodeConverterAttribute))));
+            var nodeConverters = AttributedTypes.With(typeof(FigmaNodeConverterAttribute));
 
             foreach (var type in nodeConverters)
             {
@@ -648,6 +647,75 @@ namespace Cdm.Figma.UI.Editor
             /// The asset is being assigned to the <see cref="MemberInfo"/>.
             /// </summary>
             public LazyLoadReference<Object> asset;
+        }
+    }
+
+    /// <summary>
+    /// Types carrying the importer's marker attributes, found in a single pass over the loaded
+    /// assemblies and cached. Rescanned when an assembly is added to the domain.
+    /// </summary>
+    internal static class AttributedTypes
+    {
+        private static readonly Type[] Attributes =
+        {
+            typeof(FigmaNodeAttribute),
+            typeof(FigmaComponentAttribute),
+            typeof(FigmaComponentConverterAttribute),
+            typeof(FigmaNodeConverterAttribute)
+        };
+
+        private static readonly Type[] None = Array.Empty<Type>();
+
+        private static Dictionary<Type, List<Type>> _byAttribute;
+        private static int _scannedAssemblyCount;
+
+        public static IReadOnlyList<Type> With(Type attributeType)
+        {
+            var assemblyCount = AppDomain.CurrentDomain.GetAssemblies().Length;
+
+            if (_byAttribute == null || assemblyCount != _scannedAssemblyCount)
+            {
+                _byAttribute = Scan();
+                _scannedAssemblyCount = assemblyCount;
+            }
+
+            return _byAttribute.TryGetValue(attributeType, out var types) ? types : None;
+        }
+
+        private static Dictionary<Type, List<Type>> Scan()
+        {
+            var result = new Dictionary<Type, List<Type>>();
+            foreach (var attribute in Attributes)
+            {
+                result[attribute] = new List<Type>();
+            }
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type[] types;
+                try
+                {
+                    types = assembly.GetTypes();
+                }
+                catch (ReflectionTypeLoadException e)
+                {
+                    // One assembly that cannot fully load should not take the whole import with it.
+                    types = e.Types.Where(t => t != null).ToArray();
+                }
+
+                foreach (var type in types)
+                {
+                    foreach (var attribute in Attributes)
+                    {
+                        if (type.IsDefined(attribute))
+                        {
+                            result[attribute].Add(type);
+                        }
+                    }
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/Packages/com.cdm.figma.ui/Runtime/FigmaImporter.cs
+++ b/Packages/com.cdm.figma.ui/Runtime/FigmaImporter.cs
@@ -278,6 +278,26 @@ namespace Cdm.Figma.UI
             }
         }
 
+        /// <summary>
+        /// Whether this converter is in the ignore list.
+        /// </summary>
+        /// <remarks>
+        /// Uses the default comparer rather than reference equality, because a converter outside
+        /// this package may override <see cref="object.Equals(object)"/>.
+        /// </remarks>
+        private static bool IsIgnored(INodeConverter converter, INodeConverter[] ignoredConverters)
+        {
+            var comparer = EqualityComparer<INodeConverter>.Default;
+
+            for (var i = 0; i < ignoredConverters.Length; i++)
+            {
+                if (comparer.Equals(ignoredConverters[i], converter))
+                    return true;
+            }
+
+            return false;
+        }
+
         internal bool TryConvertNode(FigmaNode parentObject, Node node, NodeConvertArgs args,
             out FigmaNode nodeObject, params INodeConverter[] ignoredConverters)
         {
@@ -290,9 +310,18 @@ namespace Cdm.Figma.UI
                 instanceNodeInitResult = args.file.InitInstanceNode(instanceNode);
             }
 
-            // Try with component converters first.
-            var componentConverter = componentConverters.FirstOrDefault(
-                c => !ignoredConverters.Contains(c) && c.CanConvert(node, args));
+            // Try with component converters first. Plain loops here and below: this runs for every
+            // node in the document, and a LINQ predicate allocates a closure on each call.
+            ComponentConverter componentConverter = null;
+            for (var i = 0; i < componentConverters.Count; i++)
+            {
+                var candidate = componentConverters[i];
+                if (!IsIgnored(candidate, ignoredConverters) && candidate.CanConvert(node, args))
+                {
+                    componentConverter = candidate;
+                    break;
+                }
+            }
 
             if (componentConverter != null)
             {
@@ -309,8 +338,16 @@ namespace Cdm.Figma.UI
             }
 
             // Try with node converters.
-            var nodeConverter = nodeConverters.FirstOrDefault(
-                c => !ignoredConverters.Contains(c) && c.CanConvert(node, args));
+            INodeConverter nodeConverter = null;
+            for (var i = 0; i < nodeConverters.Count; i++)
+            {
+                var candidate = nodeConverters[i];
+                if (!IsIgnored(candidate, ignoredConverters) && candidate.CanConvert(node, args))
+                {
+                    nodeConverter = candidate;
+                    break;
+                }
+            }
 
             if (nodeConverter != null)
             {

--- a/Packages/com.cdm.figma.ui/Runtime/FigmaImporter.cs
+++ b/Packages/com.cdm.figma.ui/Runtime/FigmaImporter.cs
@@ -194,11 +194,22 @@ namespace Cdm.Figma.UI
                 figmaDocument.rectTransform.offsetMax = new Vector2(0, 0);
 
                 var pageNodes = file.document.children;
+
+                // Only for reporting how far along the conversion is.
+                var pagesToConvert = options.selectedPages != null
+                    ? pageNodes.Count(p => options.selectedPages.Contains(p.id))
+                    : pageNodes.Length;
+                var pagesConverted = 0;
+
                 foreach (var pageNode in pageNodes)
                 {
                     // Do not import ignored pages.
                     if (options.selectedPages != null && options.selectedPages.All(p => p != pageNode.id))
                         continue;
+
+                    options.onPageProgress?.Invoke(pageNode.name,
+                        pagesToConvert > 0 ? pagesConverted / (float)pagesToConvert : 0f);
+                    pagesConverted++;
 
                     if (!TryConvertNode(figmaDocument, pageNode, conversionArgs, out var figmaNode))
                         continue;

--- a/Packages/com.cdm.figma.ui/Runtime/Integrations/UnityLocalization/UnityLocalizationStyle.cs
+++ b/Packages/com.cdm.figma.ui/Runtime/Integrations/UnityLocalization/UnityLocalizationStyle.cs
@@ -4,6 +4,7 @@ using Cdm.Figma.UI.Styles.Properties;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Localization.Components;
+using UnityEngine.Localization.Settings;
 using UnityEngine.Localization.SmartFormat.Core.Formatting;
 
 namespace Cdm.Figma.UI
@@ -12,6 +13,10 @@ namespace Cdm.Figma.UI
     public class UnityLocalizationStyle : StyleWithSetter<UnityLocalizationStyleSetter>
     {
         public StylePropertyLocalizedString localizedString = new StylePropertyLocalizedString();
+
+#if UNITY_EDITOR
+        private static bool _resolveFailureWarned;
+#endif
 
         protected override void MergeTo(Style other, bool force)
         {
@@ -43,14 +48,30 @@ namespace Cdm.Figma.UI
                 }
                 else
                 {
-                    // Importing fails while smart strings are being calculated without args.
-                    // So ignore the error in Editor.
+                    // Assigning the reference resolves the entry straight away, which an import
+                    // has no use for. The reference is stored before the resolve is attempted,
+                    // so what gets imported is the same whether or not the resolve throws.
                     try
                     {
                         stringEvent.StringReference = localizedString.value;
                     }
                     catch (FormattingException)
                     {
+                        // Smart strings are formatted without their arguments during an import.
+                    }
+                    catch (Exception e)
+                    {
+                        // The database can return a table Unity has already destroyed, and that
+                        // would otherwise take the whole import down. Resetting reloads the
+                        // tables so the remaining text nodes do not hit the same thing.
+                        LocalizationSettings.Instance.ResetState();
+
+                        if (!_resolveFailureWarned)
+                        {
+                            _resolveFailureWarned = true;
+                            Debug.LogWarning(
+                                $"Localization state was reset while importing: {e.Message}");
+                        }
                     }
                 }
 #endif

--- a/Packages/com.cdm.figma.ui/Runtime/NodeConverters/FrameNodeConverter.cs
+++ b/Packages/com.cdm.figma.ui/Runtime/NodeConverters/FrameNodeConverter.cs
@@ -57,6 +57,9 @@ namespace Cdm.Figma.UI
 
                 style.imageType.enabled = true;
                 style.imageType.value = sprite.GetImageType();
+
+                VectorNodeConverter.ApplySolidTint(style, node, args);
+
                 nodeObject.styles.Add(style);
             }
             

--- a/Packages/com.cdm.figma.ui/Runtime/NodeConverters/VectorNodeConverter.cs
+++ b/Packages/com.cdm.figma.ui/Runtime/NodeConverters/VectorNodeConverter.cs
@@ -67,6 +67,9 @@ namespace Cdm.Figma.UI
 
                 style.imageType.enabled = true;
                 style.imageType.value = sprite.GetImageType();
+
+                ApplySolidTint(style, vectorNode, args);
+
                 nodeObject.styles.Add(style);
             }
 
@@ -80,7 +83,21 @@ namespace Cdm.Figma.UI
             args.importer.ConvertEffects(nodeObject, vectorNode.effects);
         }
         
-        public static Sprite GenerateSprite(SceneNode node, FigmaNode figmaNode, 
+        /// <summary>
+        /// Applies the colour <see cref="NodeSpriteGenerator"/> leaves out of the texture when a
+        /// shape is painted in a single solid colour. Call this wherever that generator is used,
+        /// or such a shape renders white.
+        /// </summary>
+        internal static void ApplySolidTint(ImageStyle style, SceneNode node, NodeConvertArgs args)
+        {
+            if (!NodeSpriteGenerator.TryGetSolidTint(node, args.overrideNode as SceneNode, out var tint))
+                return;
+
+            style.color.enabled = true;
+            style.color.value = tint;
+        }
+
+        public static Sprite GenerateSprite(SceneNode node, FigmaNode figmaNode,
             SpriteGenerateType generateType, NodeConvertArgs args)
         {
             if (node is not INodeFill)

--- a/Packages/com.cdm.figma.ui/package.json
+++ b/Packages/com.cdm.figma.ui/package.json
@@ -1,13 +1,13 @@
 {
   "name": "com.cdm.figma.ui",
   "displayName": "Unity Figma Importer - UGUI",
-  "version": "1.9.5",
+  "version": "2.0.0",
   "unity": "2021.3",
   "author": "CDM Vision",
   "description": "Unity Figma Importer turns your Figma design into Unity UI elements and can generate code and layout files to create Unity apps.",
   "hideInEditor": false,
   "dependencies": {
-    "com.cdm.figma": "1.9.5",
+    "com.cdm.figma": "2.0.0",
     "com.unity.nuget.newtonsoft-json": "2.0.2",
     "com.unity.vectorgraphics": "2.0.0-preview.24"
   }

--- a/Packages/com.cdm.figma/CHANGELOG.md
+++ b/Packages/com.cdm.figma/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - A downloaded design is imported on the next editor tick rather than from inside the download, which left the asset pipeline holding objects from the previous import.
 - A download no longer fails when the editor rebuilds the downloader's inspector while it is running. The branch list was written through that inspector, and losing it took the file with it.
 - Switching a Figma branch no longer breaks references to the design. The design object was named after the Figma document, and Unity derives the local file ids of its components from that name, so a branch turned every stored reference into None. References that already exist need re-assigning once after upgrading.
+- A field that takes a design can be filled from a picker. The design sits on a game object inside the asset rather than as a visible sub asset, so Unity's own picker never listed it and the only way to fill the field was to drag the asset onto it.
 
 ### API
 - Added `FigmaDownloader.DownloadFileMetadataAsync`, `FigmaFile.ParseBinary(Stream, ISet<string>)`, `NodeSpriteGenerator.TryGetSolidTint` and `IFigmaImporter.Options.onPageProgress`.

--- a/Packages/com.cdm.figma/CHANGELOG.md
+++ b/Packages/com.cdm.figma/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - A thumbnail that cannot be decoded is skipped, so a design has none rather than a broken one. Figma serves WebP, which Unity cannot load.
 - A downloaded design is imported on the next editor tick rather than from inside the download, which left the asset pipeline holding objects from the previous import.
 - A download no longer fails when the editor rebuilds the downloader's inspector while it is running. The branch list was written through that inspector, and losing it took the file with it.
+- Switching a Figma branch no longer breaks references to the design. The design object was named after the Figma document, and Unity derives the local file ids of its components from that name, so a branch turned every stored reference into None. References that already exist need re-assigning once after upgrading.
 
 ### API
 - Added `FigmaDownloader.DownloadFileMetadataAsync`, `FigmaFile.ParseBinary(Stream, ISet<string>)`, `NodeSpriteGenerator.TryGetSolidTint` and `IFigmaImporter.Options.onPageProgress`.

--- a/Packages/com.cdm.figma/CHANGELOG.md
+++ b/Packages/com.cdm.figma/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-08-16
+### Changes
+- Importing a large design takes less than half the time it did.
+- Colour variants of a shape painted in one solid colour now share a sprite and a texture, roughly halving the number of sprites generated. The colour is applied through the image style.
+- Tessellation is coarser, so generated sprites differ from those of earlier versions.
+- Pages switched off in the importer settings are no longer parsed.
+- Downloading shows progress and checks the file version first, so an unchanged design can be skipped. Refreshing the branch list no longer downloads the document.
+- A thumbnail that cannot be decoded is skipped, so a design has none rather than a broken one. Figma serves WebP, which Unity cannot load.
+
+### API
+- Added `FigmaDownloader.DownloadFileMetadataAsync`, `FigmaFile.ParseBinary(Stream, ISet<string>)`, `NodeSpriteGenerator.TryGetSolidTint` and `IFigmaImporter.Options.onPageProgress`.
+- `FigmaApi.GetFileAsync` takes an optional download progress callback, and `FigmaDownloaderProgress` carries the bytes received and the current stage.
+
 ## [1.9.5] - 2026-08-14
 - No changes
 

--- a/Packages/com.cdm.figma/CHANGELOG.md
+++ b/Packages/com.cdm.figma/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Pages switched off in the importer settings are no longer parsed.
 - Downloading shows progress and checks the file version first, so an unchanged design can be skipped. Refreshing the branch list no longer downloads the document.
 - A thumbnail that cannot be decoded is skipped, so a design has none rather than a broken one. Figma serves WebP, which Unity cannot load.
+- A downloaded design is imported on the next editor tick rather than from inside the download, which left the asset pipeline holding objects from the previous import.
 
 ### API
 - Added `FigmaDownloader.DownloadFileMetadataAsync`, `FigmaFile.ParseBinary(Stream, ISet<string>)`, `NodeSpriteGenerator.TryGetSolidTint` and `IFigmaImporter.Options.onPageProgress`.

--- a/Packages/com.cdm.figma/CHANGELOG.md
+++ b/Packages/com.cdm.figma/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Downloading shows progress and checks the file version first, so an unchanged design can be skipped. Refreshing the branch list no longer downloads the document.
 - A thumbnail that cannot be decoded is skipped, so a design has none rather than a broken one. Figma serves WebP, which Unity cannot load.
 - A downloaded design is imported on the next editor tick rather than from inside the download, which left the asset pipeline holding objects from the previous import.
+- A download no longer fails when the editor rebuilds the downloader's inspector while it is running. The branch list was written through that inspector, and losing it took the file with it.
 
 ### API
 - Added `FigmaDownloader.DownloadFileMetadataAsync`, `FigmaFile.ParseBinary(Stream, ISet<string>)`, `NodeSpriteGenerator.TryGetSolidTint` and `IFigmaImporter.Options.onPageProgress`.

--- a/Packages/com.cdm.figma/Editor/FigmaAssetImporterBase.cs
+++ b/Packages/com.cdm.figma/Editor/FigmaAssetImporterBase.cs
@@ -52,9 +52,19 @@ namespace Cdm.Figma.Editor
                 Profiler.BeginSample($"Import {assetName}");
 #endif
                 var stopwatch = Stopwatch.StartNew();
-                ImportAsset(ctx);
+
+                try
+                {
+                    ImportAsset(ctx);
+                }
+                finally
+                {
+                    // Also when the import throws: a bar left up blocks the editor.
+                    EditorUtility.ClearProgressBar();
+                }
+
                 stopwatch.Stop();
-                
+
                 Debug.Log($"Importing '{ctx.assetPath}' took {stopwatch.ElapsedMilliseconds} ms.");
                 
 #if PROFILE_FIGMA_IMPORT
@@ -69,10 +79,25 @@ namespace Cdm.Figma.Editor
 #endif
         }
 
+        /// <summary>
+        /// Shows where the import has got to. An import blocks the main thread, so this call is
+        /// also what forces the repaint.
+        /// </summary>
+        /// <remarks>
+        /// Keep this to once per phase and once per page. A repaint is not free, and reporting per
+        /// node or per sprite would show up in the import time.
+        /// </remarks>
+        private static void ReportProgress(string assetPath, string step, float progress)
+        {
+            EditorUtility.DisplayProgressBar($"Importing {Path.GetFileName(assetPath)}", step, progress);
+        }
+
         private void ImportAsset(AssetImportContext ctx)
         {
             FigmaFile figmaFile;
-            
+
+            ReportProgress(ctx.assetPath, "Reading file", 0f);
+
             // Pages switched off in the settings. A list of what to drop, not what to keep, so a
             // page that is new in the file is parsed rather than imported empty. Null on a first
             // import, which is what populates the page list in the first place.
@@ -87,13 +112,20 @@ namespace Cdm.Figma.Editor
             
             UpdatePages(figmaFile);
 
+            ReportProgress(ctx.assetPath, "Preparing converters", 0.2f);
+
             var figmaImporter = GetFigmaImporter(ctx);
             OnAssetImporting(ctx, figmaImporter, figmaFile);
 
+            // Page conversion is the long part, so it drives 0.25 to 0.9 of the bar.
             var figmaDesign = figmaImporter.ImportFile(figmaFile, new IFigmaImporter.Options()
             {
-                selectedPages = _pages.Where(p => p.enabled).Select(p => p.id).ToArray()
+                selectedPages = _pages.Where(p => p.enabled).Select(p => p.id).ToArray(),
+                onPageProgress = (pageName, fraction) =>
+                    ReportProgress(ctx.assetPath, $"Converting {pageName}", 0.25f + fraction * 0.65f)
             });
+
+            ReportProgress(ctx.assetPath, "Finalizing", 0.95f);
 
             OnAssetImported(ctx, figmaImporter, figmaFile, figmaDesign);
 

--- a/Packages/com.cdm.figma/Editor/FigmaAssetImporterBase.cs
+++ b/Packages/com.cdm.figma/Editor/FigmaAssetImporterBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -72,9 +73,16 @@ namespace Cdm.Figma.Editor
         {
             FigmaFile figmaFile;
             
+            // Pages switched off in the settings. A list of what to drop, not what to keep, so a
+            // page that is new in the file is parsed rather than imported empty. Null on a first
+            // import, which is what populates the page list in the first place.
+            var skipPageIds = importSettingsMissing || _pages == null
+                ? null
+                : new HashSet<string>(_pages.Where(p => !p.enabled).Select(p => p.id));
+
             using (var compressedStream = File.Open(ctx.assetPath, FileMode.Open))
             {
-                figmaFile = FigmaFile.ParseBinary(compressedStream);    
+                figmaFile = FigmaFile.ParseBinary(compressedStream, skipPageIds);
             }
             
             UpdatePages(figmaFile);

--- a/Packages/com.cdm.figma/Editor/FigmaDesignPropertyDrawer.cs
+++ b/Packages/com.cdm.figma/Editor/FigmaDesignPropertyDrawer.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace Cdm.Figma.Editor
+{
+    /// <summary>
+    /// Gives <see cref="FigmaDesign"/> fields a working picker.
+    /// </summary>
+    /// <remarks>
+    /// The importer registers the design's game object with the asset, and the components on it are
+    /// not visible sub assets, so Unity's own picker finds nothing of this type and the only way to
+    /// fill the field is to drag the asset onto it. The button added here lists the designs in the
+    /// project instead. Dragging still works, because the object field is still an object field.
+    /// </remarks>
+    [CustomPropertyDrawer(typeof(FigmaDesign), useForChildren: true)]
+    public class FigmaDesignPropertyDrawer : PropertyDrawer
+    {
+        private const float ButtonWidth = 24f;
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+
+            var fieldRect = new Rect(position) { width = position.width - ButtonWidth };
+            var buttonRect = new Rect(position) { xMin = fieldRect.xMax };
+
+            var designType = GetDesignType();
+
+            EditorGUI.BeginChangeCheck();
+            var picked = EditorGUI.ObjectField(
+                fieldRect, label, property.objectReferenceValue, designType, allowSceneObjects: false);
+            if (EditorGUI.EndChangeCheck())
+            {
+                property.objectReferenceValue = picked;
+            }
+
+            if (EditorGUI.DropdownButton(buttonRect, new GUIContent("...", "Pick a Figma design"),
+                    FocusType.Passive, EditorStyles.miniButton))
+            {
+                ShowMenu(property, designType);
+            }
+
+            EditorGUI.EndProperty();
+        }
+
+        /// <summary>
+        /// The element type for a list or array field, the field type otherwise.
+        /// </summary>
+        private Type GetDesignType()
+        {
+            var type = fieldInfo.FieldType;
+
+            if (type.IsArray)
+            {
+                type = type.GetElementType();
+            }
+            else if (type.IsGenericType && type.GetGenericArguments().Length == 1)
+            {
+                type = type.GetGenericArguments()[0];
+            }
+
+            return type != null && typeof(FigmaDesign).IsAssignableFrom(type) ? type : typeof(FigmaDesign);
+        }
+
+        private static void ShowMenu(SerializedProperty property, Type designType)
+        {
+            // A SerializedProperty is not safe to hold on to past this frame, so the menu items
+            // re-fetch it from the serialized object by path when one of them is chosen.
+            var serializedObject = property.serializedObject;
+            var propertyPath = property.propertyPath;
+            var current = property.objectReferenceValue;
+
+            void Assign(UnityEngine.Object value)
+            {
+                serializedObject.Update();
+                serializedObject.FindProperty(propertyPath).objectReferenceValue = value;
+                serializedObject.ApplyModifiedProperties();
+            }
+
+            var menu = new GenericMenu();
+            menu.AddItem(new GUIContent("None"), current == null, () => Assign(null));
+
+            var designs = FindDesigns(designType);
+            if (designs.Count == 0)
+            {
+                menu.AddDisabledItem(new GUIContent("No design of this type in the project"));
+            }
+            else
+            {
+                menu.AddSeparator("");
+
+                foreach (var (design, assetPath) in designs)
+                {
+                    var title = string.IsNullOrEmpty(design.title) ? design.name : design.title;
+                    var entry = $"{Path.GetFileNameWithoutExtension(assetPath)} ({title})";
+
+                    var captured = design;
+                    menu.AddItem(new GUIContent(entry), ReferenceEquals(current, design),
+                        () => Assign(captured));
+                }
+            }
+
+            menu.ShowAsContext();
+        }
+
+        private static List<(FigmaDesign design, string assetPath)> FindDesigns(Type designType)
+        {
+            var extensions = GetDesignExtensions();
+            var results = new List<(FigmaDesign, string)>();
+
+            // Filtered by extension before anything is loaded: the alternative is loading every
+            // GameObject asset in the project, prefabs included, to look for one component.
+            foreach (var assetPath in AssetDatabase.GetAllAssetPaths())
+            {
+                if (!assetPath.StartsWith("Assets/", StringComparison.Ordinal))
+                    continue;
+
+                if (!extensions.Contains(Path.GetExtension(assetPath)))
+                    continue;
+
+                var go = AssetDatabase.LoadAssetAtPath<GameObject>(assetPath);
+                if (go == null)
+                    continue;
+
+                if (go.GetComponent(designType) is FigmaDesign design)
+                {
+                    results.Add((design, assetPath));
+                }
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// The default extension plus whatever the downloaders in this project are set to write.
+        /// </summary>
+        private static HashSet<string> GetDesignExtensions()
+        {
+            var extensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".figma" };
+
+            foreach (var guid in AssetDatabase.FindAssets($"t:{nameof(FigmaDownloaderAsset)}"))
+            {
+                var downloader =
+                    AssetDatabase.LoadAssetAtPath<FigmaDownloaderAsset>(AssetDatabase.GUIDToAssetPath(guid));
+
+                if (downloader != null && !string.IsNullOrEmpty(downloader.assetExtension))
+                {
+                    extensions.Add("." + downloader.assetExtension.TrimStart('.'));
+                }
+            }
+
+            return extensions;
+        }
+    }
+}

--- a/Packages/com.cdm.figma/Editor/FigmaDesignPropertyDrawer.cs.meta
+++ b/Packages/com.cdm.figma/Editor/FigmaDesignPropertyDrawer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dd8e4c87a2a8a374dba5d685cc441399

--- a/Packages/com.cdm.figma/Editor/FigmaDownloaderAssetEditor.cs
+++ b/Packages/com.cdm.figma/Editor/FigmaDownloaderAssetEditor.cs
@@ -329,33 +329,41 @@ namespace Cdm.Figma.Editor
             }
         }
 
-        private void UpdateBranches(FigmaFile file)
+        private static void UpdateBranches(FigmaDownloaderAsset downloader, FigmaFile file)
         {
-            _branches.arraySize = 0;
+            // Through its own serialized object rather than the inspector's: a download outlives
+            // the inspector that started it whenever the editor rebuilds one, and the properties
+            // held there are disposed with it. OnInspectorGUI calls Update() before it draws, so
+            // the inspector picks this up rather than writing a stale copy back over it.
+            var serializedDownloader = new SerializedObject(downloader);
+            var branches = serializedDownloader.FindProperty("_branches");
+            var selectedBranch = serializedDownloader.FindProperty("_branch");
+
+            branches.arraySize = 0;
 
             if (file.branches != null)
             {
-                _branches.arraySize = file.branches.Length;
+                branches.arraySize = file.branches.Length;
 
                 for (var i = 0; i < file.branches.Length; i++)
                 {
-                    var branch = _branches.GetArrayElementAtIndex(i);
+                    var branch = branches.GetArrayElementAtIndex(i);
                     branch.FindPropertyRelative("key").stringValue = file.branches[i].key;
                     branch.FindPropertyRelative("name").stringValue = file.branches[i].name;
                 }
-                
-                var isSelectedBranchExist = file.branches.Any(x => x.key == _branch.stringValue);
+
+                var isSelectedBranchExist = file.branches.Any(x => x.key == selectedBranch.stringValue);
                 if (!isSelectedBranchExist)
                 {
-                    _branch.stringValue = "";
+                    selectedBranch.stringValue = "";
                 }
             }
             else
             {
-                _branch.stringValue = "";
+                selectedBranch.stringValue = "";
             }
 
-            serializedObject.ApplyModifiedProperties();
+            serializedDownloader.ApplyModifiedProperties();
         }
 
         private async void RefreshBranchesAsync()
@@ -390,7 +398,7 @@ namespace Cdm.Figma.Editor
                     downloader.personalAccessToken, downloader.fileId, downloader.fileVersion,
                     cancellationToken);
 
-            UpdateBranches(newFile);
+            UpdateBranches(downloader, newFile);
         }
 
         /// <summary>
@@ -471,7 +479,7 @@ namespace Cdm.Figma.Editor
 
             if (!newFile.IsBranch())
             {
-                UpdateBranches(newFile);
+                UpdateBranches(downloader, newFile);
             }
             
             var directory = Path.Combine("Assets", downloader.assetPath);

--- a/Packages/com.cdm.figma/Editor/FigmaDownloaderAssetEditor.cs
+++ b/Packages/com.cdm.figma/Editor/FigmaDownloaderAssetEditor.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using UnityEditor;
 using UnityEngine;
 using CompressionLevel = System.IO.Compression.CompressionLevel;
@@ -34,6 +35,8 @@ namespace Cdm.Figma.Editor
         private bool _isRefreshingBranchesCompleted = false;
         private string _downloadingFile = "";
         private float _downloadingProgress = 0f;
+        private long _downloadedBytes = 0;
+        private string _downloadingStage = "";
         private CancellationTokenSource _cancellationTokenSource;
 
         protected virtual void OnEnable()
@@ -110,9 +113,16 @@ namespace Cdm.Figma.Editor
 
             if (_isDownloading)
             {
-                var description = !_isDownloadingDependency
-                    ? $"File: {_downloadingFile}"
-                    : $"File dependency: {_downloadingFile}";
+                var what = !_isDownloadingDependency ? _downloadingFile : $"dependency {_downloadingFile}";
+                var description = string.IsNullOrEmpty(_downloadingStage)
+                    ? what
+                    : $"{_downloadingStage}: {what}";
+
+                // Usually no content length to build a fraction from, so show the byte count.
+                if (_downloadedBytes > 0)
+                {
+                    description += $"  ({_downloadedBytes / 1024f / 1024f:F1} MB)";
+                }
 
                 if (EditorUtility.DisplayCancelableProgressBar(
                         "Downloading Figma File", description, _downloadingProgress))
@@ -219,12 +229,64 @@ namespace Cdm.Figma.Editor
             await DownloadFilesAsync((FigmaDownloaderAsset)target);
         }
 
+        /// <summary>
+        /// Checks whether the remote file differs from the one on disk, and if it does not, lets the
+        /// user decide whether to download it anyway.
+        /// </summary>
+        /// <remarks>
+        /// Asks rather than decides: downloading anyway is the escape hatch when the file on disk
+        /// is suspected to have drifted, and it writes the file like any other download so that it
+        /// can repair one. Every failure path returns true, because a check that cannot answer must
+        /// not be the reason a download does not happen.
+        /// </remarks>
+        private static async Task<bool> ShouldDownloadAsync(FigmaDownloaderAsset downloader,
+            string fileKey, CancellationToken cancellationToken)
+        {
+            var fileName = string.IsNullOrEmpty(downloader.fileName)
+                ? downloader.defaultFileName
+                : downloader.fileName;
+
+            if (string.IsNullOrEmpty(fileName))
+                return true;
+
+            var storedVersion = ReadStoredVersion(GetFigmaAssetPath(downloader, fileName));
+            if (string.IsNullOrEmpty(storedVersion))
+                return true;
+
+            string remoteVersion;
+            try
+            {
+                remoteVersion = await GetRemoteVersionAsync(downloader, fileKey, cancellationToken);
+            }
+            catch (TaskCanceledException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"Could not check the Figma file version, downloading anyway: {e.Message}");
+                return true;
+            }
+
+            if (string.IsNullOrEmpty(remoteVersion) || remoteVersion != storedVersion)
+                return true;
+
+            return EditorUtility.DisplayDialog(
+                "Figma file is up to date",
+                $"'{fileName}' is already at the latest version ({storedVersion}).\n\n" +
+                "Downloading again will fetch the same content and reimport the asset.",
+                "Download anyway", "Skip");
+        }
+
         private async Task DownloadFilesAsync(FigmaDownloaderAsset downloader)
         {
             try
             {
                 _isDownloading = true;
                 _downloadingProgress = 0f;
+                _downloadedBytes = 0;
+
+                _downloadingStage = "";
 
                 var fileKey = downloader.fileId;
                 var branch = _branch.stringValue;
@@ -234,6 +296,12 @@ namespace Cdm.Figma.Editor
                 }
                 
                 _downloadingFile = downloader.fileId;
+
+                if (!await ShouldDownloadAsync(downloader, fileKey, _cancellationTokenSource.Token))
+                {
+                    Debug.Log("Figma file is already up to date, download skipped.");
+                    return;
+                }
 
                 await DownloadAndSaveFigmaFileAsync(downloader, fileKey, _cancellationTokenSource.Token);
 
@@ -253,6 +321,9 @@ namespace Cdm.Figma.Editor
                 _isDownloadingCompleted = true;
                 _isDownloadingDependency = false;
                 _downloadingProgress = 0f;
+                _downloadedBytes = 0;
+
+                _downloadingStage = "";
 
                 _cancellationTokenSource.Dispose();
             }
@@ -309,19 +380,77 @@ namespace Cdm.Figma.Editor
             }
         }
 
-        private async Task RefreshBranchesAsync(FigmaDownloaderAsset downloader, 
+        private async Task RefreshBranchesAsync(FigmaDownloaderAsset downloader,
             CancellationToken cancellationToken = default)
         {
+            // Metadata only: a full download would pull the document, images and dependencies to
+            // read two strings per branch out of the result.
             var newFile = await downloader.GetDownloader()
-                .DownloadFileAsync(downloader.personalAccessToken, downloader.fileId, downloader.fileVersion,
-                    new Progress<FigmaDownloaderProgress>(
-                        progress =>
-                        {
-                            _isDownloadingDependency = false;
-                            _downloadingFile = progress.fileId;
-                        }), cancellationToken);
-            
+                .DownloadFileMetadataAsync(
+                    downloader.personalAccessToken, downloader.fileId, downloader.fileVersion,
+                    cancellationToken);
+
             UpdateBranches(newFile);
+        }
+
+        /// <summary>
+        /// The version of the file already on disk, or null if there is none to read.
+        /// </summary>
+        /// <remarks>
+        /// Read from the stored json rather than the imported asset, so it still works when the
+        /// last import failed, and stops at <c>version</c> instead of reading the document.
+        /// <para>Parsed rather than pattern matched: a pattern would also match a <c>version</c>
+        /// nested inside the document, and a wrong value that happens to equal the remote one
+        /// skips a real update silently.</para>
+        /// </remarks>
+        private static string ReadStoredVersion(string path)
+        {
+            if (!File.Exists(path))
+                return null;
+
+            try
+            {
+                using var file = File.OpenRead(path);
+                using var decompressor = new GZipStream(file, CompressionMode.Decompress);
+                using var streamReader = new StreamReader(decompressor);
+                // Defaults, so this reads the field the same way the remote side parses it.
+                using var reader = new JsonTextReader(streamReader);
+
+                if (!reader.Read() || reader.TokenType != JsonToken.StartObject)
+                    return null;
+
+                while (reader.Read() && reader.TokenType == JsonToken.PropertyName)
+                {
+                    if ((string)reader.Value == "version")
+                        return reader.ReadAsString();
+
+                    // Step over the value without descending into it.
+                    reader.Read();
+                    reader.Skip();
+                }
+
+                return null;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Asks Figma for the file's current version without downloading the document.
+        /// </summary>
+        /// <remarks>
+        /// Figma changes version only when the document changes.
+        /// </remarks>
+        private static async Task<string> GetRemoteVersionAsync(FigmaDownloaderAsset downloader,
+            string fileKey, CancellationToken cancellationToken)
+        {
+            var file = await downloader.GetDownloader()
+                .DownloadFileMetadataAsync(
+                    downloader.personalAccessToken, fileKey, downloader.fileVersion, cancellationToken);
+
+            return file.version;
         }
 
         private async Task DownloadAndSaveFigmaFileAsync(
@@ -334,6 +463,10 @@ namespace Cdm.Figma.Editor
                         {
                             _isDownloadingDependency = progress.isDependency;
                             _downloadingFile = progress.fileId;
+
+                            _downloadingProgress = progress.progress;
+                            _downloadedBytes = progress.bytesDownloaded;
+                            _downloadingStage = progress.stage;
                         }), cancellationToken);
 
             if (!newFile.IsBranch())
@@ -356,14 +489,19 @@ namespace Cdm.Figma.Editor
             var figmaAssetPath = GetFigmaAssetPath(downloader, fileName);
 
             // Save as compressed file.
-            using var content = new MemoryStream(Encoding.UTF8.GetBytes(newFile.ToString("N")));
-            await using var compressedFileStream = File.Create(figmaAssetPath);
-            await using var compressor = new GZipStream(compressedFileStream, CompressionLevel.Optimal);
-            await content.CopyToAsync(compressor, cancellationToken);
-
-            //await File.WriteAllTextAsync(figmaAssetPath, newFile.ToString("N"), cancellationToken);
+            using (var content = new MemoryStream(Encoding.UTF8.GetBytes(newFile.ToString("N"))))
+            await using (var compressedFileStream = File.Create(figmaAssetPath))
+            await using (var compressor = new GZipStream(compressedFileStream, CompressionLevel.Optimal))
+            {
+                await content.CopyToAsync(compressor, cancellationToken);
+            }
 
             Debug.Log($"Figma file saved at: {figmaAssetPath}");
+
+            // Explicitly, rather than leaving it to the AssetDatabase.Refresh() in OnInspectorGUI:
+            // that needs a repaint, and does nothing at all with auto refresh off. The streams above
+            // must be closed first or the importer reads a partial file.
+            AssetDatabase.ImportAsset(figmaAssetPath, ImportAssetOptions.ForceUpdate);
         }
 
         private static string GetFigmaAssetPath(FigmaDownloaderAsset downloader, string fileName)

--- a/Packages/com.cdm.figma/Editor/FigmaDownloaderAssetEditor.cs
+++ b/Packages/com.cdm.figma/Editor/FigmaDownloaderAssetEditor.cs
@@ -508,11 +508,17 @@ namespace Cdm.Figma.Editor
 
             // Explicitly, rather than leaving it to the AssetDatabase.Refresh() in OnInspectorGUI:
             // that needs a repaint, and does nothing at all with auto refresh off. The streams above
-            // must be closed first or the importer reads a partial file. Deferred rather than
-            // imported here, because importing from a task continuation leaves the asset pipeline
-            // holding objects from the previous import.
-            EditorApplication.delayCall +=
-                () => AssetDatabase.ImportAsset(figmaAssetPath, ImportAssetOptions.ForceUpdate);
+            // must be closed first or the importer reads a partial file. On the next editor tick
+            // rather than here, so that downloading reports its own progress and importing reports
+            // its own. Through update rather than delayCall, which does not run while the editor
+            // sits in the background, and a long download is exactly when it does.
+            EditorApplication.CallbackFunction importOnce = null;
+            importOnce = () =>
+            {
+                EditorApplication.update -= importOnce;
+                AssetDatabase.ImportAsset(figmaAssetPath, ImportAssetOptions.ForceUpdate);
+            };
+            EditorApplication.update += importOnce;
         }
 
         private static string GetFigmaAssetPath(FigmaDownloaderAsset downloader, string fileName)

--- a/Packages/com.cdm.figma/Editor/FigmaDownloaderAssetEditor.cs
+++ b/Packages/com.cdm.figma/Editor/FigmaDownloaderAssetEditor.cs
@@ -500,8 +500,11 @@ namespace Cdm.Figma.Editor
 
             // Explicitly, rather than leaving it to the AssetDatabase.Refresh() in OnInspectorGUI:
             // that needs a repaint, and does nothing at all with auto refresh off. The streams above
-            // must be closed first or the importer reads a partial file.
-            AssetDatabase.ImportAsset(figmaAssetPath, ImportAssetOptions.ForceUpdate);
+            // must be closed first or the importer reads a partial file. Deferred rather than
+            // imported here, because importing from a task continuation leaves the asset pipeline
+            // holding objects from the previous import.
+            EditorApplication.delayCall +=
+                () => AssetDatabase.ImportAsset(figmaAssetPath, ImportAssetOptions.ForceUpdate);
         }
 
         private static string GetFigmaAssetPath(FigmaDownloaderAsset downloader, string fileName)

--- a/Packages/com.cdm.figma/Runtime/Figma/FigmaFile.cs
+++ b/Packages/com.cdm.figma/Runtime/Figma/FigmaFile.cs
@@ -309,15 +309,90 @@ namespace Cdm.Figma
         
         public static FigmaFile ParseBinary(Stream stream)
         {
-            using var decompressedStream = new MemoryStream();
-            using var decompressor = new GZipStream(stream, CompressionMode.Decompress);
-            decompressor.CopyTo(decompressedStream);
+            return ParseBinary(stream, null);
+        }
 
-            decompressedStream.Position = 0;
-            using var streamReader = new StreamReader(decompressedStream);
-            var fileJson = streamReader.ReadToEnd();
-            
-            return Parse(fileJson);
+        /// <summary>
+        /// Parses the file without materialising the contents of the pages in
+        /// <paramref name="skipPageIds"/>.
+        /// </summary>
+        /// <remarks>
+        /// Skipped pages keep their page node, emptied, so the importer's page list still offers
+        /// them, and keep any component definitions inside them, so instances on imported pages
+        /// still resolve. Pass null to parse everything.
+        /// <para>Takes the pages to skip rather than the pages to keep, so a page that is new in
+        /// the file, and therefore in no selection yet, is parsed rather than silently emptied.
+        /// </para>
+        /// </remarks>
+        public static FigmaFile ParseBinary(Stream stream, ISet<string> skipPageIds)
+        {
+            using var decompressor = new GZipStream(stream, CompressionMode.Decompress);
+            using var streamReader = new StreamReader(decompressor);
+
+            // Leave the reader's date handling alone. Turning it off hands IsoDateTimeConverter the
+            // raw string, and that converter is configured AssumeUniversal without
+            // AdjustToUniversal, which shifts a UTC timestamp into local time and then stamps a Z
+            // on it.
+            using var jsonReader = new JsonTextReader(streamReader);
+
+            // The node converter calls JToken.Load, so the document becomes a token tree either
+            // way. Building it here costs nothing extra and keeps one path for both cases.
+            var root = JObject.Load(jsonReader);
+
+            if (skipPageIds != null && skipPageIds.Count > 0)
+            {
+                PruneUnselectedPages(root, skipPageIds);
+            }
+
+            return root.ToObject<FigmaFile>(JsonHelper.CreateSerializer());
+        }
+
+        /// <summary>
+        /// Empties the pages that are not being imported, keeping the page node and any component
+        /// definitions found anywhere inside it.
+        /// </summary>
+        private static void PruneUnselectedPages(JObject root, ISet<string> skipPageIds)
+        {
+            if (root["document"]?["children"] is not JArray pages)
+                return;
+
+            foreach (var page in pages)
+            {
+                var id = (string)page["id"];
+                if (id == null || !skipPageIds.Contains(id))
+                    continue;
+
+                if (page["children"] is not JArray children)
+                    continue;
+
+                var components = new JArray();
+                foreach (var child in children)
+                {
+                    CollectComponents(child, components);
+                }
+
+                // Flattened rather than kept in place: the page is never converted, so only lookup
+                // by id matters, and BuildHierarchy indexes at any depth.
+                page["children"] = components;
+            }
+        }
+
+        private static void CollectComponents(JToken node, JArray into)
+        {
+            var type = (string)node["type"];
+            if (type == "COMPONENT" || type == "COMPONENT_SET")
+            {
+                into.Add(node);
+                return;
+            }
+
+            if (node["children"] is JArray children)
+            {
+                foreach (var child in children)
+                {
+                    CollectComponents(child, into);
+                }
+            }
         }
 
         public override string ToString()

--- a/Packages/com.cdm.figma/Runtime/Figma/Nodes/Node.cs
+++ b/Packages/com.cdm.figma/Runtime/Figma/Nodes/Node.cs
@@ -57,6 +57,14 @@ namespace Cdm.Figma
         public ComponentPropertyReferences componentPropertyReferences { get; set; }
 
         /// <summary>
+        /// Parsed <see cref="PluginData"/> for this node, resolved on first use. Only valid while
+        /// <see cref="pluginData"/> is left alone, which it is after deserialization.
+        /// </summary>
+        internal PluginData cachedPluginData { get; set; }
+
+        internal bool cachedPluginDataResolved { get; set; }
+
+        /// <summary>
         /// Parent of the node.
         /// </summary>
         public Node parent { get; set; }

--- a/Packages/com.cdm.figma/Runtime/Figma/Nodes/NodeExtensions.cs
+++ b/Packages/com.cdm.figma/Runtime/Figma/Nodes/NodeExtensions.cs
@@ -181,14 +181,20 @@ namespace Cdm.Figma
 
         public static bool TryGetPluginData(this Node node, out PluginData pluginData)
         {
-            if (node.pluginData != null && node.pluginData.TryGetValue(PluginData.Id, out var data))
+            // Parsed once per node: conversion asks each candidate converter, so this is called
+            // several times for the same node.
+            if (!node.cachedPluginDataResolved)
             {
-                pluginData = PluginData.FromJson(data);
-                return pluginData != null;
+                if (node.pluginData != null && node.pluginData.TryGetValue(PluginData.Id, out var data))
+                {
+                    node.cachedPluginData = PluginData.FromJson(data);
+                }
+
+                node.cachedPluginDataResolved = true;
             }
 
-            pluginData = null;
-            return false;
+            pluginData = node.cachedPluginData;
+            return pluginData != null;
         }
     }
 }

--- a/Packages/com.cdm.figma/Runtime/Figma/PluginData.cs
+++ b/Packages/com.cdm.figma/Runtime/Figma/PluginData.cs
@@ -46,7 +46,7 @@ namespace Cdm.Figma
 
         public static PluginData FromJson(JObject json)
         {
-            return FromString(json.ToString());
+            return json.ToObject<PluginData>(JsonHelper.CreateSerializer());
         }
 
         public T GetComponentDataAs<T>() where T : class

--- a/Packages/com.cdm.figma/Runtime/FigmaDesign.cs
+++ b/Packages/com.cdm.figma/Runtime/FigmaDesign.cs
@@ -52,6 +52,8 @@ namespace Cdm.Figma
             private set => _thumbnail = value;
         }
         
+        private static bool _thumbnailDecodeWarned;
+
         public static T Create<T>(FigmaFile file) where T : FigmaDesign
         {
             var go = new GameObject(file.name);
@@ -67,10 +69,32 @@ namespace Cdm.Figma
                 try
                 {
                     var thumbnailData = Convert.FromBase64String(file.thumbnail);
-                    figmaFile.thumbnail = new Texture2D(1, 1);
-                    figmaFile.thumbnail.name = "Thumbnail";
-                    figmaFile.thumbnail.LoadImage(thumbnailData);
-                    
+
+                    var texture = new Texture2D(1, 1);
+                    texture.name = "Thumbnail";
+
+                    // LoadImage handles PNG and JPEG only. Figma serves WebP, so this fails and
+                    // leaves an 8x8 placeholder behind. Better no thumbnail than a broken one.
+                    if (texture.LoadImage(thumbnailData))
+                    {
+                        figmaFile.thumbnail = texture;
+                    }
+                    else
+                    {
+                        DestroyTexture(texture);
+
+                        // Once per domain. With Figma serving WebP this is the usual outcome, and
+                        // repeating it on every import would just be noise.
+                        if (!_thumbnailDecodeWarned)
+                        {
+                            _thumbnailDecodeWarned = true;
+
+                            Debug.LogWarning(
+                                $"Thumbnail of '{file.name}' could not be decoded and has been skipped. " +
+                                "Unity loads PNG and JPEG only, and Figma serves thumbnails as WebP.");
+                        }
+                    }
+
 #if UNITY_EDITOR
                     figmaFile.hideFlags = HideFlags.NotEditable;
 #endif
@@ -82,6 +106,21 @@ namespace Cdm.Figma
             }
 
             return figmaFile;
+        }
+
+        /// <summary>
+        /// Disposes of a texture that is not going to be used.
+        /// </summary>
+        private static void DestroyTexture(Texture2D texture)
+        {
+#if UNITY_EDITOR
+            if (!Application.isPlaying)
+            {
+                UnityEngine.Object.DestroyImmediate(texture);
+                return;
+            }
+#endif
+            UnityEngine.Object.Destroy(texture);
         }
     }
 }

--- a/Packages/com.cdm.figma/Runtime/FigmaDesign.cs
+++ b/Packages/com.cdm.figma/Runtime/FigmaDesign.cs
@@ -56,8 +56,13 @@ namespace Cdm.Figma
 
         public static T Create<T>(FigmaFile file) where T : FigmaDesign
         {
-            var go = new GameObject(file.name);
-            
+            // A constant, not file.name. Unity derives the local file ids of the components on this
+            // object from its name, and a Figma branch carries its own document name, so switching
+            // branches moved those ids and every reference stored elsewhere in the project turned
+            // into None. The importer renames this object to the asset file name anyway, and the
+            // document name is kept on title just below.
+            var go = new GameObject(nameof(FigmaDesign));
+
             var figmaFile = go.AddComponent<T>();
             figmaFile.id = file.fileId;
             figmaFile.title = file.name;

--- a/Packages/com.cdm.figma/Runtime/FigmaDownloader.cs
+++ b/Packages/com.cdm.figma/Runtime/FigmaDownloader.cs
@@ -33,7 +33,7 @@ namespace Cdm.Figma
                 {
                     _downloadedFiles = new Dictionary<string, FigmaFile>();
                     return await DownloadFileAsyncInternal(
-                        personalAccessToken, fileId, fileVersion, false, progress, cancellationToken);
+                        personalAccessToken, fileId, fileVersion, false, progress, 0f, 1f, cancellationToken);
                 }
             }
             finally
@@ -43,12 +43,74 @@ namespace Cdm.Figma
             }
         }
 
+        /// <summary>
+        /// Downloads a file's metadata: its name, version and branches, without the document.
+        /// </summary>
+        /// <remarks>
+        /// Uses <c>depth=1</c>, which returns the pages and nothing below them. Branch data is
+        /// unaffected by depth.
+        /// </remarks>
+        public virtual async Task<FigmaFile> DownloadFileMetadataAsync(
+            string personalAccessToken, string fileId, string fileVersion = "",
+            CancellationToken cancellationToken = default)
+        {
+            using var api = new FigmaApi(personalAccessToken);
+
+            var fileContentJson = await api.GetFileAsync(
+                new FileRequest(fileId)
+                {
+                    version = fileVersion,
+                    depth = 1,
+                    includeBranchData = true
+                }, cancellationToken);
+
+            var file = FigmaFile.Parse(fileContentJson);
+            file.fileId = fileId;
+            return file;
+        }
+
+        /// <summary>
+        /// How far through the transfer to report, out of the 40% of a file's progress it covers.
+        /// </summary>
+        /// <remarks>
+        /// Figma usually sends these chunked, with no content length to build a fraction from, so
+        /// without a length this approaches the limit without reaching it: always moving, never
+        /// claiming to be done.
+        /// </remarks>
+        private static float DownloadFraction(long bytesRead, long? totalBytes)
+        {
+            const float downloadShare = 0.4f;
+
+            if (totalBytes.HasValue && totalBytes.Value > 0)
+                return (float)(bytesRead / (double)totalBytes.Value) * downloadShare;
+
+            // Half way to the limit at 16 MB, the rough order of these files.
+            const double scale = 16.0 * 1024 * 1024;
+            return (float)(downloadShare * (1.0 - scale / (scale + bytesRead)));
+        }
+
+        /// <param name="progressStart">Where this file's own 0 to 1 sits in the reported bar.</param>
+        /// <param name="progressSpan">
+        /// How much of the reported bar this file's own 0 to 1 covers.
+        /// </param>
+        /// <remarks>
+        /// A dependency recurses into here, so without a range it would report from zero again and
+        /// send the bar backwards.
+        /// </remarks>
         private async Task<FigmaFile> DownloadFileAsyncInternal(
             string personalAccessToken, string fileId, string fileVersion,
-            bool isDependency, IProgress<FigmaDownloaderProgress> progress, CancellationToken cancellationToken)
+            bool isDependency, IProgress<FigmaDownloaderProgress> progress,
+            float progressStart, float progressSpan, CancellationToken cancellationToken)
         {
-            progress?.Report(new FigmaDownloaderProgress(fileId, 0f, isDependency));
+            void Report(float fraction, long bytesDownloaded, string stage)
+            {
+                progress?.Report(new FigmaDownloaderProgress(
+                    fileId, progressStart + fraction * progressSpan, isDependency, bytesDownloaded, stage));
+            }
 
+            Report(0f, 0, "Connecting");
+
+            // The transfer covers the first 40% of this file, the rest covers what follows it.
             var fileContentJson = await _figmaApi.GetFileAsync(
                 new FileRequest(fileId)
                 {
@@ -56,7 +118,12 @@ namespace Cdm.Figma
                     geometry = "paths",
                     plugins = new[] { PluginData.Id },
                     includeBranchData = true
-                }, cancellationToken);
+                }, cancellationToken,
+                (bytesRead, totalBytes) => Report(DownloadFraction(bytesRead, totalBytes), bytesRead, "Downloading"));
+
+            // Deserializing a large document takes seconds, so name the stage rather than
+            // leaving the bar sitting at the end of the transfer.
+            Report(0.45f, fileContentJson.Length, "Reading file");
 
             var file = FigmaFile.Parse(fileContentJson);
             file.fileId = fileId;
@@ -65,6 +132,8 @@ namespace Cdm.Figma
             {
                 if (!string.IsNullOrEmpty(file.thumbnailUrl))
                 {
+                    Report(0.6f, 0, "Downloading thumbnail");
+
                     try
                     {
                         var thumbnail = await _figmaApi.GetThumbnailImageAsync(file.thumbnailUrl, cancellationToken);
@@ -81,6 +150,9 @@ namespace Cdm.Figma
 
                 if (downloadImages)
                 {
+                    // One request for every image fill, which is slow on a design with many.
+                    Report(0.65f, 0, "Downloading images");
+
                     var images = await _figmaApi.GetImageFillsAsync(new ImageFillsRequest(fileId), cancellationToken);
 
                     foreach (var image in images)
@@ -96,19 +168,21 @@ namespace Cdm.Figma
 
             if (downloadDependencies)
             {
-                progress?.Report(new FigmaDownloaderProgress(fileId, 0.5f, isDependency));
+                Report(0.75f, 0, "Downloading dependencies");
 
-                file.fileDependencies =
-                    await DownloadFileDependenciesAsync(file, personalAccessToken, progress, cancellationToken);
+                // Dependencies share the last quarter of this file's range.
+                file.fileDependencies = await DownloadFileDependenciesAsync(
+                    file, personalAccessToken, progress,
+                    progressStart + 0.75f * progressSpan, 0.25f * progressSpan, cancellationToken);
             }
 
-            progress?.Report(new FigmaDownloaderProgress(fileId, 1f, isDependency));
+            Report(1f, 0, "");
             return file;
         }
 
         private async Task<FigmaFileDependency[]> DownloadFileDependenciesAsync(
             FigmaFile mainFile, string personalAccessToken, IProgress<FigmaDownloaderProgress> progress,
-            CancellationToken cancellationToken)
+            float progressStart, float progressSpan, CancellationToken cancellationToken)
         {
             // Find external components.
             var missingComponents = new Dictionary<string, List<string>>();
@@ -116,8 +190,15 @@ namespace Cdm.Figma
 
             var fileDependencies = new Dictionary<string, FigmaFileDependency>();
 
+            // An equal slice per lookup, so the bar moves forwards however many files this pulls.
+            var componentSpan = missingComponents.Count > 0 ? progressSpan / missingComponents.Count : 0f;
+            var componentIndex = 0;
+
             foreach (var missingComponent in missingComponents)
             {
+                var componentStart = progressStart + componentIndex * componentSpan;
+                componentIndex++;
+
                 try
                 {
                     var componentMetadata =
@@ -130,7 +211,8 @@ namespace Cdm.Figma
                         if (!_downloadedFiles.ContainsKey(componentMetadata.fileKey))
                         {
                             await DownloadFileAsyncInternal(
-                                personalAccessToken, componentMetadata.fileKey, "", true, progress, cancellationToken);
+                                personalAccessToken, componentMetadata.fileKey, "", true, progress,
+                                componentStart, componentSpan, cancellationToken);
                         }
 
                         {

--- a/Packages/com.cdm.figma/Runtime/IFigmaDownloader.cs
+++ b/Packages/com.cdm.figma/Runtime/IFigmaDownloader.cs
@@ -30,11 +30,30 @@ namespace Cdm.Figma
         /// </summary>
         public float progress { get; }
 
+        /// <summary>
+        /// Bytes received so far, or 0 when that is not being tracked. Separate from
+        /// <see cref="progress"/>, which has no content length to work from on a chunked response.
+        /// </summary>
+        public long bytesDownloaded { get; }
+
+        /// <summary>
+        /// What is happening right now, for display. Empty when not reported.
+        /// </summary>
+        public string stage { get; }
+
         public FigmaDownloaderProgress(string fileId, float progress, bool isDependency)
+            : this(fileId, progress, isDependency, 0, "")
+        {
+        }
+
+        public FigmaDownloaderProgress(string fileId, float progress, bool isDependency,
+            long bytesDownloaded, string stage = "")
         {
             this.fileId = fileId;
             this.progress = progress;
             this.isDependency = isDependency;
+            this.bytesDownloaded = bytesDownloaded;
+            this.stage = stage;
         }
     }
 }

--- a/Packages/com.cdm.figma/Runtime/IFigmaImporter.cs
+++ b/Packages/com.cdm.figma/Runtime/IFigmaImporter.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Cdm.Figma
 {
     public interface IFigmaImporter
@@ -8,10 +10,19 @@ namespace Cdm.Figma
         /// <param name="file">The Figma file to be imported.</param>
         /// <param name="options">Importer options.</param>
         FigmaDesign ImportFile(FigmaFile file, Options options = null);
-        
+
         public class Options
         {
             public string[] selectedPages { get; set; }
+
+            /// <summary>
+            /// Called as each page is about to be converted, with the page name and how far through
+            /// the selected pages this is, from 0 to 1.
+            /// </summary>
+            /// <remarks>
+            /// A plain callback, so this stays independent of the editor.
+            /// </remarks>
+            public Action<string, float> onPageProgress { get; set; }
         }
     }
 }

--- a/Packages/com.cdm.figma/Runtime/Json/JsonHelper.cs
+++ b/Packages/com.cdm.figma/Runtime/Json/JsonHelper.cs
@@ -12,12 +12,20 @@ namespace Cdm.Figma.Json
     {
         public static T Deserialize<T>(string json)
         {
-            var serializer = JsonSerializer.Create(CreateSettings());
+            var serializer = CreateSerializer();
 
             using (var reader = new JsonTextReader(new StringReader(json)))
             {
                 return serializer.Deserialize<T>(reader);
             }
+        }
+
+        /// <summary>
+        /// Creates a serializer configured the same way <see cref="Deserialize{T}"/> configures one.
+        /// </summary>
+        public static JsonSerializer CreateSerializer()
+        {
+            return JsonSerializer.Create(CreateSettings());
         }
 
         public static string Serialize(object value, Formatting formatting = Formatting.None)

--- a/Packages/com.cdm.figma/Runtime/Json/SubTypeJsonConverter.cs
+++ b/Packages/com.cdm.figma/Runtime/Json/SubTypeJsonConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -6,6 +7,13 @@ namespace Cdm.Figma.Json
 {
     public abstract class SubTypeJsonConverter<TObjectType, TTypeToken> : JsonConverter
     {
+        // A document has many values but few distinct discriminators, so both lookups are memoised.
+        // Not thread safe, and does not need to be: an instance belongs to one serializer.
+        private readonly Dictionary<string, TTypeToken> _typeTokens =
+            new Dictionary<string, TTypeToken>(StringComparer.Ordinal);
+
+        private readonly Dictionary<Type, Func<object>> _creators = new Dictionary<Type, Func<object>>();
+
         protected virtual string GetTypeToken()
         {
             return "type";
@@ -16,19 +24,53 @@ namespace Cdm.Figma.Json
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
             JsonSerializer serializer)
         {
-            var token = JToken.Load(reader);
+            // Nested values arrive through a JTokenReader over a tree that already exists, and
+            // JToken.Load would deep copy the subtree at every level, copying a node once per
+            // ancestor. Reuse the token that is there and step the reader past it.
+            JToken token;
+            if (reader is JTokenReader tokenReader && tokenReader.CurrentToken != null)
+            {
+                token = tokenReader.CurrentToken;
+                reader.Skip();
+            }
+            else
+            {
+                token = JToken.Load(reader);
+            }
 
             var typeToken = token[GetTypeToken()];
             if (typeToken == null)
                 throw new JsonReaderException($"Missing {typeof(TTypeToken).Name} type.");
 
-            if (!TryGetActualType(typeToken.ToObject<TTypeToken>(serializer), out var actualType))
+            TTypeToken typeTokenValue;
+            if (typeToken.Type == JTokenType.String)
+            {
+                var key = (string)typeToken;
+                if (!_typeTokens.TryGetValue(key, out typeTokenValue))
+                {
+                    // Through the serializer, so enum member naming and any converter on the enum
+                    // still apply.
+                    typeTokenValue = typeToken.ToObject<TTypeToken>(serializer);
+                    _typeTokens.Add(key, typeTokenValue);
+                }
+            }
+            else
+            {
+                typeTokenValue = typeToken.ToObject<TTypeToken>(serializer);
+            }
+
+            if (!TryGetActualType(typeTokenValue, out var actualType))
                 throw new JsonReaderException($"Unknown {nameof(PaintType)} got: '{typeToken}'.");
 
             if (existingValue == null || existingValue.GetType() != actualType)
             {
-                var contract = serializer.ContractResolver.ResolveContract(actualType);
-                existingValue = contract?.DefaultCreator?.Invoke();
+                if (!_creators.TryGetValue(actualType, out var creator))
+                {
+                    creator = serializer.ContractResolver.ResolveContract(actualType)?.DefaultCreator;
+                    _creators.Add(actualType, creator);
+                }
+
+                existingValue = creator?.Invoke();
             }
 
             if (existingValue == null)

--- a/Packages/com.cdm.figma/Runtime/Utils/NodeSpriteGenerator.cs
+++ b/Packages/com.cdm.figma/Runtime/Utils/NodeSpriteGenerator.cs
@@ -31,6 +31,11 @@ namespace Cdm.Figma.Utils
     
     public class NodeSpriteGenerator
     {
+        /// <summary>
+        /// White, in the form <c>AppendSvgSolid</c> writes a paint.
+        /// </summary>
+        private const string WhiteSvgColor = "#FFFFFF";
+
         private readonly Dictionary<string, Sprite> _sprites = new Dictionary<string, Sprite>();
 
         /// <summary>
@@ -65,7 +70,20 @@ namespace Cdm.Figma.Utils
             }
 
             var svg = GenerateSvgFromPath(node, options.Value.overrideNode, options.Value);
-            
+
+            // A shape painted in one solid colour is rasterized white and coloured through its
+            // style instead, so colour variants share a single entry in the sprite cache below.
+            // The converter applies the colour: see VectorNodeConverter.ApplySolidTint.
+            if (TryGetSolidTint(node, options.Value.overrideNode, out _, out var svgColor))
+            {
+                var neutralized = svg.content.Replace(svgColor, WhiteSvgColor);
+
+                if (!ReferenceEquals(neutralized, svg.content))
+                {
+                    svg = new SvgString(svg.node, neutralized) { dontResize = svg.dontResize };
+                }
+            }
+
 #if FIGMA_PRINT_SVG_STRING
             Debug.Log($"{svg.node}: {svg.content}");
 #endif
@@ -103,6 +121,98 @@ namespace Cdm.Figma.Utils
             return generatedSprite;
         }
         
+        /// <summary>
+        /// Whether every visible paint on this node is the same single solid colour, which is the
+        /// condition for rasterizing the shape white and applying the colour through the style.
+        /// A gradient, an image fill, or a fill and stroke of different colours all disqualify it,
+        /// because <see cref="UnityEngine.UI.Graphic.color"/> multiplies the whole sprite and
+        /// cannot reproduce two colours.
+        /// </summary>
+        /// <remarks>
+        /// Called by both the SVG generation and the converter that writes the style, so the two
+        /// always agree. Paints are compared by the text they produce in the SVG, through the same
+        /// <c>rgb-hex</c> call <c>AppendSvgSolid</c> uses, which keeps the comparison exact and
+        /// makes <paramref name="svgColor"/> match what is in the document.
+        /// <para>An unqualified <c>Color</c> in this namespace is Figma's own colour type.</para>
+        /// </remarks>
+        public static bool TryGetSolidTint(SceneNode node, SceneNode overrideNode,
+            out UnityEngine.Color tint)
+        {
+            return TryGetSolidTint(node, overrideNode, out tint, out _);
+        }
+
+        /// <param name="svgColor">
+        /// How that colour is written in the generated SVG, so the generator can take it back out.
+        /// </param>
+        /// <inheritdoc cref="TryGetSolidTint(SceneNode,SceneNode,out UnityEngine.Color)"/>
+        public static bool TryGetSolidTint(SceneNode node, SceneNode overrideNode,
+            out UnityEngine.Color tint, out string svgColor)
+        {
+            tint = UnityEngine.Color.white;
+            svgColor = null;
+
+            if (node is not INodeFill nodeFill)
+                return false;
+
+            var fills = nodeFill.fills;
+            var strokes = nodeFill.strokes;
+
+            if (overrideNode is INodeFill overrideNodeFill)
+            {
+                fills = overrideNodeFill.fills;
+                strokes = overrideNodeFill.strokes;
+            }
+
+            var color = default(Color);
+
+            if (!CollectSolidColor(fills, ref svgColor, ref color))
+                return false;
+
+            if (!CollectSolidColor(strokes, ref svgColor, ref color))
+                return false;
+
+            if (svgColor == null)
+                return false;
+
+            // Per paint opacity stays baked into the texture's alpha, so only RGB is hoisted.
+            tint = (UnityEngine.Color)color;
+            tint.a = 1f;
+            return true;
+        }
+
+        /// <summary>
+        /// Accumulates the single colour shared by every visible paint, or reports failure as soon
+        /// as a second colour or a non solid paint shows up.
+        /// </summary>
+        private static bool CollectSolidColor(List<Paint> paints, ref string svgColor, ref Color color)
+        {
+            if (paints == null)
+                return true;
+
+            foreach (var paint in paints)
+            {
+                if (!paint.visible)
+                    continue;
+
+                if (paint is not SolidPaint solid)
+                    return false;
+
+                var current = solid.color.ToString("rgb-hex");
+
+                if (svgColor == null)
+                {
+                    svgColor = current;
+                    color = solid.color;
+                }
+                else if (!string.Equals(current, svgColor, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         /// <summary>
         /// Generates SVG string from the scene node.
         /// </summary>

--- a/Packages/com.cdm.figma/Runtime/Utils/SpriteGenerateOptions.cs
+++ b/Packages/com.cdm.figma/Runtime/Utils/SpriteGenerateOptions.cs
@@ -64,7 +64,11 @@ namespace Cdm.Figma.Utils
             {
                 tessellationOptions = new VectorUtils.TessellationOptions()
                 {
-                    StepDistance = 1.0f,
+                    // One segment per this many units of arc length, and arcs are subdivided by
+                    // StepDistance / radius, so curve quality stays proportional to size.
+                    // float.MaxValue is a sentinel that drops the radius term and facets large
+                    // circles badly, so keep this a real value.
+                    StepDistance = 2.0f,
                     MaxCordDeviation = 0.5f,
                     MaxTanAngleDeviation = 0.1f,
                     SamplingStepSize = 0.01f

--- a/Packages/com.cdm.figma/Runtime/WebApi/FigmaApi.cs
+++ b/Packages/com.cdm.figma/Runtime/WebApi/FigmaApi.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Cdm.Figma.Json;
@@ -39,7 +41,12 @@ namespace Cdm.Figma
         /// The components key contains a mapping from node IDs to component metadata. This is to help you
         /// determine which components each instance comes from.
         /// </summary>
-        public async Task<string> GetFileAsync(FileRequest fileRequest, CancellationToken cancellationToken = default)
+        /// <param name="downloadProgress">
+        /// Called with the bytes received so far, and the total if the server sent one. The total is
+        /// often absent on a chunked response, so callers must cope without it.
+        /// </param>
+        public async Task<string> GetFileAsync(FileRequest fileRequest,
+            CancellationToken cancellationToken = default, Action<long, long?> downloadProgress = null)
         {
             if (string.IsNullOrEmpty(fileRequest.fileId))
                 throw new ArgumentException("File ID cannot be empty.");
@@ -47,10 +54,45 @@ namespace Cdm.Figma
             var url = GetFileRequestUrl(fileRequest);
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
 
-            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            // ResponseHeadersRead so the body can be read as it arrives. The default buffers the
+            // whole response first, leaving nothing to report until it is already done.
+            using var response = await _httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
-            return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var contentLength = response.Content.Headers.ContentLength;
+
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var buffer = new MemoryStream(
+                contentLength.HasValue ? (int)Math.Min(contentLength.Value, int.MaxValue) : 1 << 20);
+
+            var chunk = new byte[1 << 16];
+            var lastReported = 0L;
+
+            while (true)
+            {
+                var read = await stream.ReadAsync(chunk, 0, chunk.Length, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (read <= 0)
+                    break;
+
+                buffer.Write(chunk, 0, read);
+
+                // Throttled: a report per chunk would be thousands of repaints.
+                if (downloadProgress != null && buffer.Length - lastReported >= (1 << 20))
+                {
+                    lastReported = buffer.Length;
+                    downloadProgress(buffer.Length, contentLength);
+                }
+            }
+
+            // Through a reader rather than Encoding.UTF8.GetString, which would leave a byte order
+            // mark in place and make the document unparseable.
+            buffer.Position = 0;
+            using var bufferReader = new StreamReader(buffer, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            return await bufferReader.ReadToEndAsync().ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Packages/com.cdm.figma/package.json
+++ b/Packages/com.cdm.figma/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.cdm.figma",
   "displayName": "Unity Figma Importer",
-  "version": "1.9.5",
+  "version": "2.0.0",
   "unity": "2021.3",
   "author": "CDM Vision",
   "description": "Unity Figma Importer turns your Figma design into Unity UI and can generate code and layout files to create Unity apps.",


### PR DESCRIPTION
Publishes 2.0.0. Content merged in #100.

Two things to know before updating:

- Every design is reimported once.
- **Every reference to a design needs re-assigning once.** The design object is no longer named after the Figma document, which is what stops switching a Figma branch from turning those references into None.

| import | before | after | |
|---|---|---|---|
| SuPAR Composer | 23.7 s | 10.4 s | -56% |
| SuPAR | 33.5 s | 13.6 s | -59% |

Full notes in the package changelogs.
